### PR TITLE
fixes issue #18

### DIFF
--- a/upath/__init__.py
+++ b/upath/__init__.py
@@ -1,4 +1,4 @@
 """Pathlib API extended to use fsspec backends"""
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 from upath.core import UPath

--- a/upath/core.py
+++ b/upath/core.py
@@ -10,9 +10,9 @@ from upath.registry import _registry
 class UPath(pathlib.Path):
     def __new__(cls, *args, **kwargs):
         if cls is UPath:
-            new_args = list(args)
-            first_arg = new_args.pop(0)
-            parsed_url = urllib.parse.urlparse(first_arg)
+            args_list = list(args)
+            url = args_list.pop(0)
+            parsed_url = urllib.parse.urlparse(url)
             for key in ["scheme", "netloc"]:
                 val = kwargs.get(key)
                 if val:
@@ -34,8 +34,8 @@ class UPath(pathlib.Path):
             else:
                 cls = _registry[parsed_url.scheme]
                 kwargs["_url"] = parsed_url
-                new_args.insert(0, parsed_url.path)
-                args = tuple(new_args)
+                args_list.insert(0, parsed_url.path)
+                args = tuple(args_list)
                 self = cls._from_parts_init(args, init=False)
                 self._init(*args, **kwargs)
         return self

--- a/upath/tests/implementations/test_s3.py
+++ b/upath/tests/implementations/test_s3.py
@@ -83,3 +83,15 @@ class TestUPathS3(BaseTests):
         upath2 = UPath(p2, anon=self.anon, **self.s3so)
         assert upath2.read_bytes() == content
         upath2.unlink()
+
+    @pytest.mark.parametrize(
+        "joiner", [["bucket", "path", "file"], "bucket/path/file"]
+    )
+    def test_no_bucket_joinpath(self, joiner):
+        path = UPath("s3://", anon=self.anon, **self.s3so)
+        path = path.joinpath(joiner)
+        assert str(path) == "s3://bucket/path/file"
+
+    def test_creating_s3path_with_bucket(self):
+        path = UPath("s3://", bucket="bucket", anon=self.anon, **self.s3so)
+        assert str(path) == "s3://bucket/"


### PR DESCRIPTION
adds keyword  `bucket` to `S3Path` so a user can create a `S3Path` object without using f-string. 

```python
>>>UPath('s3://', bucket='bucket', **connection_kwargs)
S3Path('s3://bucket/')
```

Also adds functionality to `S3Path().joinpath` so that a bucket can be the first part of a joined path
```python
>>>UPath('s3://', **connection_kwargs).joinpath('bucket', 'some', 'path')
S3Path('s3://bucket/some/path')
>>>UPath('s3://', **connection_kwargs).joinpath('bucket/some/path')
S3Path('s3://bucket/some/path')
```